### PR TITLE
Add support for multiple platforms by converging the arch module into a common one.

### DIFF
--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -1,1 +1,2 @@
-pub mod x86_64;
+#[cfg_attr(target_arch = "x86_64", path = "./x86_64/mod.rs")]
+pub mod common;

--- a/kernel/src/arch/x86_64/entry.rs
+++ b/kernel/src/arch/x86_64/entry.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::arch::x86_64::{serial, asm};
+use crate::arch::common::{asm, serial};
 
 pub fn entry() {
     serial::init();

--- a/kernel/src/arch/x86_64/serial.rs
+++ b/kernel/src/arch/x86_64/serial.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::arch::x86_64::ports;
+use crate::arch::common::ports;
 
 const PORT: u16 = 0x3f8;
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -17,7 +17,7 @@
 #![no_std]
 #![no_main]
 
-use runix::arch::x86_64::{entry, asm};
+use runix::arch::common::{asm, entry};
 
 use limine::LimineFramebufferRequest;
 static FRAMEBUFFER_REQUEST: LimineFramebufferRequest = LimineFramebufferRequest::new(0);


### PR DESCRIPTION
This uses the "cfg_attr" attribute to change the "path" attribute depending on the target architecture.

This will make it possible to port Runix to other architectures in the future.